### PR TITLE
Guard NNUE header I/O for empty descriptions

### DIFF
--- a/src/nnue/evaluate_nnue.cpp
+++ b/src/nnue/evaluate_nnue.cpp
@@ -100,7 +100,8 @@ namespace Stockfish::Eval::NNUE {
     size        = read_little_endian<std::uint32_t>(stream);
     if (!stream || version != Version) return false;
     desc->resize(size);
-    stream.read(&(*desc)[0], size);
+    if (size > 0)
+      stream.read(desc->data(), size);
     return !stream.fail();
   }
 
@@ -110,7 +111,8 @@ namespace Stockfish::Eval::NNUE {
     write_little_endian<std::uint32_t>(stream, Version);
     write_little_endian<std::uint32_t>(stream, hashValue);
     write_little_endian<std::uint32_t>(stream, desc.size());
-    stream.write(&desc[0], desc.size());
+    if (!desc.empty())
+      stream.write(desc.data(), desc.size());
     return !stream.fail();
   }
 


### PR DESCRIPTION
## Summary
- avoid dereferencing empty NNUE description buffers by guarding read_header and write_header calls

## Testing
- /tmp/test_zero_desc


------
https://chatgpt.com/codex/tasks/task_e_68ce0e6243908330bb566e7d80932816