### PR TITLE
Improve stat bonus scaling for deep searches

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -85,7 +85,9 @@ namespace {
 
   // History and stats update bonus, based on depth
   int stat_bonus(Depth d) {
-    return d > 14 ? 73 : 6 * d * d + 229 * d - 215;
+    constexpr int MaxBonus = 10692;
+    int bonus = 6 * d * d + 229 * d - 215;
+    return std::clamp(bonus, -MaxBonus, MaxBonus);
   }
 
   // Add a small random component to draw evaluations to avoid 3-fold blindness


### PR DESCRIPTION
## Summary
- extend `stat_bonus()` to keep its quadratic scaling for depths beyond 14
- clamp bonuses to the maximum supported by the 16-bit history tables to avoid overflow

## Testing
- `make -C src build -j2`
- `cd src && python3 - <<'PY' ...` (perft checks for standard chess positions)


------
https://chatgpt.com/codex/tasks/task_e_68ce0f3af16c8330b0e983fbcca6f324