### PR TITLE
Guard gate history updates for non-gating moves

### DIFF
--- a/src/movepick.cpp
+++ b/src/movepick.cpp
@@ -109,18 +109,24 @@ void MovePicker::score() {
 
   for (auto& m : *this)
       if constexpr (Type == CAPTURES)
+      {
+          int gateScore = has_gate(m) ? (*gateHistory)[pos.side_to_move()][gating_square(m)] : 0;
           m.value =  int(PieceValue[MG][pos.piece_on(to_sq(m))]) * 6
-                   + (*gateHistory)[pos.side_to_move()][gating_square(m)]
+                   + gateScore
                    + (*captureHistory)[pos.moved_piece(m)][to_sq(m)][type_of(pos.piece_on(to_sq(m)))];
+      }
 
       else if constexpr (Type == QUIETS)
+      {
+          int gateScore = has_gate(m) ? (*gateHistory)[pos.side_to_move()][gating_square(m)] : 0;
           m.value =      (*mainHistory)[pos.side_to_move()][from_to(m)]
-                   +     (*gateHistory)[pos.side_to_move()][gating_square(m)]
+                   +     gateScore
                    + 2 * (*continuationHistory[0])[history_slot(pos.moved_piece(m))][to_sq(m)]
                    +     (*continuationHistory[1])[history_slot(pos.moved_piece(m))][to_sq(m)]
                    +     (*continuationHistory[3])[history_slot(pos.moved_piece(m))][to_sq(m)]
                    +     (*continuationHistory[5])[history_slot(pos.moved_piece(m))][to_sq(m)]
                    + (ply < MAX_LPH ? std::min(4, depth / 3) * (*lowPlyHistory)[ply][from_to(m)] : 0);
+      }
 
       else // Type == EVASIONS
       {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -800,7 +800,7 @@ namespace {
             {
                 int penalty = -stat_bonus(depth);
                 thisThread->mainHistory[us][from_to(ttMove)] << penalty;
-                if (pos.walling())
+                if (pos.walling() && has_gate(ttMove))
                     thisThread->gateHistory[us][gating_square(ttMove)] << penalty;
                 update_continuation_histories(ss, pos.moved_piece(ttMove), to_sq(ttMove), penalty);
             }
@@ -1324,8 +1324,9 @@ moves_loop: // When in check, search starts from here
               if (ttCapture)
                   r++;
 
+              int gateScore = has_gate(move) ? thisThread->gateHistory[us][gating_square(move)] * 2 : 0;
               ss->statScore =  thisThread->mainHistory[us][from_to(move)]
-                             + thisThread->gateHistory[us][gating_square(move)] * 2
+                             + gateScore
                              + (*contHist[0])[history_slot(movedPiece)][to_sq(move)]
                              + (*contHist[1])[history_slot(movedPiece)][to_sq(move)]
                              + (*contHist[3])[history_slot(movedPiece)][to_sq(move)]
@@ -1825,7 +1826,7 @@ moves_loop: // When in check, search starts from here
         {
             if (!(pos.walling() && from_to(quietsSearched[i]) == from_to(bestMove)))
                 thisThread->mainHistory[us][from_to(quietsSearched[i])] << -bonus2;
-            if (pos.walling())
+            if (pos.walling() && has_gate(quietsSearched[i]))
                 thisThread->gateHistory[us][gating_square(quietsSearched[i])] << -bonus2;
             update_continuation_histories(ss, pos.moved_piece(quietsSearched[i]), to_sq(quietsSearched[i]), -bonus2);
         }
@@ -1834,7 +1835,7 @@ moves_loop: // When in check, search starts from here
     {
         // Increase stats for the best move in case it was a capture move
         captureHistory[moved_piece][to_sq(bestMove)][captured] << bonus1;
-        if (pos.walling())
+        if (pos.walling() && has_gate(bestMove))
             thisThread->gateHistory[us][gating_square(bestMove)] << bonus1;
     }
 
@@ -1851,7 +1852,7 @@ moves_loop: // When in check, search starts from here
         captured = type_of(pos.piece_on(to_sq(capturesSearched[i])));
         if (!(pos.walling() && from_to(capturesSearched[i]) == from_to(bestMove)))
             captureHistory[moved_piece][to_sq(capturesSearched[i])][captured] << -bonus1;
-        if (pos.walling())
+        if (pos.walling() && has_gate(capturesSearched[i]))
             thisThread->gateHistory[us][gating_square(capturesSearched[i])] << -bonus1;
     }
   }
@@ -1887,7 +1888,7 @@ moves_loop: // When in check, search starts from here
     Color us = pos.side_to_move();
     Thread* thisThread = pos.this_thread();
     thisThread->mainHistory[us][from_to(move)] << bonus;
-    if (pos.walling())
+    if (pos.walling() && has_gate(move))
         thisThread->gateHistory[us][gating_square(move)] << bonus;
     update_continuation_histories(ss, pos.moved_piece(move), to_sq(move), bonus);
 

--- a/src/types.h
+++ b/src/types.h
@@ -818,6 +818,11 @@ inline bool is_gating(Move m) {
   return gating_type(m) && (type_of(m) == NORMAL || type_of(m) == CASTLING);
 }
 
+inline bool has_gate(Move m) {
+  constexpr int GateShift = 2 * SQUARE_BITS + MOVE_TYPE_BITS + PIECE_TYPE_BITS;
+  return is_gating(m) || ((m >> GateShift) & SQUARE_BIT_MASK);
+}
+
 inline bool is_pass(Move m) {
   return type_of(m) == SPECIAL && from_sq(m) == to_sq(m);
 }


### PR DESCRIPTION
## Summary
- add a helper to detect moves that actually carry a gate or wall target
- guard move ordering and history updates so non-gating moves do not touch gate history

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce10993e108330a57b7909c4fe8f43