### PR TITLE
Fix parsing for standalone h Betza modifier

### DIFF
--- a/src/piece.cpp
+++ b/src/piece.cpp
@@ -62,6 +62,7 @@ namespace {
       bool lame = false;
       bool initial = false;
       int distance = 0;
+      bool standaloneH = false;
       std::vector<std::string> prelimDirections = {};
       for (std::string::size_type i = 0; i < betza.size(); i++)
       {
@@ -99,7 +100,14 @@ namespace {
                       continue;
                   }
               }
-              prelimDirections.push_back(std::string(2, c));
+              if (c == 'h')
+              {
+                  prelimDirections.push_back("hr");
+                  prelimDirections.push_back("hl");
+                  standaloneH = true;
+              }
+              else
+                  prelimDirections.push_back(std::string(2, c));
           }
           // Move atom
           else if (leaperAtoms.find(c) != leaperAtoms.end() || riderAtoms.find(c) != riderAtoms.end())
@@ -132,7 +140,7 @@ namespace {
                   // Split directions for orthogonal pieces
                   // This is required e.g. to correctly interpret fsW for soldiers
                   for (auto s : prelimDirections)
-                      if (atoms.size() == 1 && atom.second == 0 && s[0] != s[1])
+                      if (atoms.size() == 1 && atom.second == 0 && s[0] != s[1] && s != "hr" && s != "hl")
                       {
                           directions.push_back(std::string(2, s[0]));
                           directions.push_back(std::string(2, s[1]));
@@ -148,9 +156,9 @@ namespace {
                       auto has_dir = [&](std::string s) {
                         return std::find(directions.begin(), directions.end(), s) != directions.end();
                       };
-                      if (directions.size() == 0 || has_dir("ff") || has_dir("vv") || has_dir("rf") || has_dir("rv") || has_dir("fh") || has_dir("rh") || has_dir("hr"))
+                      if (directions.size() == 0 || has_dir("ff") || has_dir("vv") || has_dir("rf") || has_dir("rv") || has_dir("fh") || has_dir("rh") || (!standaloneH && has_dir("hr")))
                           v[Direction(atom.first * FILE_NB + atom.second)] = distance;
-                      if (directions.size() == 0 || has_dir("bb") || has_dir("vv") || has_dir("lb") || has_dir("lv") || has_dir("bh") || has_dir("lh") || has_dir("hr"))
+                      if (directions.size() == 0 || has_dir("bb") || has_dir("vv") || has_dir("lb") || has_dir("lv") || has_dir("bh") || has_dir("lh") || (!standaloneH && has_dir("hr")))
                           v[Direction(-atom.first * FILE_NB - atom.second)] = distance;
                       if (directions.size() == 0 || has_dir("rr") || has_dir("ss") || has_dir("br") || has_dir("bs") || has_dir("bh") || has_dir("rh") || has_dir("hr"))
                           v[Direction(-atom.second * FILE_NB + atom.first)] = distance;
@@ -160,9 +168,9 @@ namespace {
                           v[Direction(atom.second * FILE_NB + atom.first)] = distance;
                       if (directions.size() == 0 || has_dir("ll") || has_dir("ss") || has_dir("bl") || has_dir("bs") || has_dir("bh") || has_dir("lh") || has_dir("hl"))
                           v[Direction(-atom.second * FILE_NB - atom.first)] = distance;
-                      if (directions.size() == 0 || has_dir("bb") || has_dir("vv") || has_dir("rb") || has_dir("rv") || has_dir("bh") || has_dir("rh") || has_dir("hl"))
+                      if (directions.size() == 0 || has_dir("bb") || has_dir("vv") || has_dir("rb") || has_dir("rv") || has_dir("bh") || has_dir("rh") || (!standaloneH && has_dir("hl")))
                           v[Direction(-atom.first * FILE_NB + atom.second)] = distance;
-                      if (directions.size() == 0 || has_dir("ff") || has_dir("vv") || has_dir("lf") || has_dir("lv") || has_dir("fh") || has_dir("lh") || has_dir("hl"))
+                      if (directions.size() == 0 || has_dir("ff") || has_dir("vv") || has_dir("lf") || has_dir("lv") || has_dir("fh") || has_dir("lh") || (!standaloneH && has_dir("hl")))
                           v[Direction(atom.first * FILE_NB - atom.second)] = distance;
                   }
               }
@@ -174,6 +182,7 @@ namespace {
               lame = false;
               initial = false;
               distance = 0;
+              standaloneH = false;
           }
       }
       return p;

--- a/test.py
+++ b/test.py
@@ -99,6 +99,7 @@ customPiece1 = a:lhN
 customPiece2 = b:rhN
 customPiece3 = c:hlN
 customPiece4 = d:hrN
+customPiece5 = e:hW
 startFen = 7/7/7/3A3/7/7/7 w - - 0 1
 
 [cannonshogi:shogi]
@@ -415,6 +416,8 @@ class TestPyffish(unittest.TestCase):
         self.assertEqual(['d4e2', 'd4b3', 'd4f5', 'd4c6'], result)
         result = sf.legal_moves("betzatest", "7/7/7/3D3/7/7/7 w - - 0 1", [])
         self.assertEqual(['d4c2', 'd4f3', 'd4b5', 'd4e6'], result)
+        result = sf.legal_moves("betzatest", "7/7/7/3E3/7/7/7 w - - 0 1", [])
+        self.assertEqual(['d4c4', 'd4e4'], result)
 
 
     def test_castling(self):


### PR DESCRIPTION
## Summary
- emit hr/hl tokens for unpaired h modifiers and track their presence while parsing Betza strings
- prevent standalone h from enabling vertical directions so horizontal-only moves such as hW are generated
- extend the betzatest regression to cover the hW piece

## Testing
- python3 test.py *(fails: ModuleNotFoundError: No module named 'pyffish')*

------
https://chatgpt.com/codex/tasks/task_e_68ce10ed536c83309e919bdf5598c7ad