### PR TITLE
Allow cambodian counting rule config

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -93,7 +93,7 @@ namespace {
                 : value == "cambodian" ? CAMBODIAN_COUNTING
                 : value == "asean" ? ASEAN_COUNTING
                 : NO_COUNTING;
-        return value == "makruk" || value == "asean" || value == "none";
+        return value == "makruk" || value == "cambodian" || value == "asean" || value == "none";
     }
 
     template <> bool set(const std::string& value, ChasingRule& target) {

--- a/test.py
+++ b/test.py
@@ -315,6 +315,18 @@ class TestPyffish(unittest.TestCase):
         result = sf.set_option("UCI_Variant", "capablanca")
         self.assertIsNone(result)
 
+    def test_load_variant_config_cambodian_counting_rule(self):
+        config = (
+            "[cambodian_count_rule_variant:makruk]\n"
+            "countingRule = cambodian\n"
+        )
+        try:
+            sf.load_variant_config(config)
+        except sf.error as err:
+            self.fail(f"load_variant_config raised an exception: {err}")
+
+        self.assertEqual(sf.start_fen("cambodian_count_rule_variant"), MAKRUK)
+
     def test_two_boards(self):
         self.assertFalse(sf.two_boards("chess"))
         self.assertTrue(sf.two_boards("bughouse"))


### PR DESCRIPTION
## Summary
- allow countingRule parser to accept the cambodian keyword
- add a regression test that loads a variant config using countingRule=cambodian

## Testing
- python3 test.py *(fails: ModuleNotFoundError: No module named 'pyffish')*

------
https://chatgpt.com/codex/tasks/task_e_68ce173fc044833085db0698d9269c3d