### PR TITLE
Simplify non-root Euclidian distance calculation

### DIFF
--- a/src/apiutil.h
+++ b/src/apiutil.h
@@ -25,7 +25,6 @@
 #include <sstream>
 #include <cctype>
 #include <iostream>
-#include <math.h>
 
 #include "types.h"
 #include "position.h"
@@ -480,7 +479,9 @@ inline bool operator!=(const CharSquare& s1, const CharSquare& s2) {
 }
 
 inline int non_root_euclidian_distance(const CharSquare& s1, const CharSquare& s2) {
-    return pow(s1.rowIdx - s2.rowIdx, 2) + pow(s1.fileIdx - s2.fileIdx, 2);
+    int rowDelta = s1.rowIdx - s2.rowIdx;
+    int fileDelta = s1.fileIdx - s2.fileIdx;
+    return rowDelta * rowDelta + fileDelta * fileDelta;
 }
 
 class CharBoard {


### PR DESCRIPTION
## Summary
- replace expensive pow usage in non_root_euclidian_distance with integer delta multiplications
- drop the now-unused <math.h> include from apiutil.h

## Testing
- python3 test.py *(fails: ModuleNotFoundError: No module named 'pyffish')*

------
https://chatgpt.com/codex/tasks/task_e_68ce1a3bd20c83308e7e49091fd8bcc0