### PR TITLE
Guard CharBoard placements against invalid indexes

### DIFF
--- a/src/apiutil.h
+++ b/src/apiutil.h
@@ -493,8 +493,15 @@ public:
         assert(nbFiles > 0 && nbRanks > 0);
         board = std::vector<char>(nbRanks * nbFiles, ' ');
     }
-    void set_piece(int rankIdx, int fileIdx, char c) {
+    Validation set_piece(int rankIdx, int fileIdx, char c) {
+        if (rankIdx < 0 || rankIdx >= nbRanks || fileIdx < 0 || fileIdx >= nbFiles)
+        {
+            std::cerr << "Invalid board index (rank: " << rankIdx << ", file: " << fileIdx
+                      << ") for board of size " << nbRanks << "x" << nbFiles << "." << std::endl;
+            return NOK;
+        }
         board[rankIdx * nbFiles + fileIdx] = c;
+        return OK;
     }
     char get_piece(int rowIdx, int fileIdx) const {
         return board[rowIdx * nbFiles + fileIdx];
@@ -651,12 +658,14 @@ inline Validation fill_char_board(CharBoard& board, const std::string& fenBoard,
         }
         else if (!contains(validSpecialCharactersFirstField, c))
         {  // normal piece
-            if (fileIdx == board.get_nb_files())
+            if (fileIdx >= board.get_nb_files())
             {
                 std::cerr << "File index: " << fileIdx << " for piece '" << c << "' exceeds maximum of allowed number of files: " << board.get_nb_files() << "." << std::endl;
                 return NOK;
             }
-            board.set_piece(v->maxRank-rankIdx, fileIdx, c);  // we mirror the rank index because the black pieces are given first in the FEN
+            if (board.set_piece(v->maxRank-rankIdx, fileIdx, c) == NOK)
+                return NOK;
+            // we mirror the rank index because the black pieces are given first in the FEN
             ++fileIdx;
         }
         prevChar = c;

--- a/test.py
+++ b/test.py
@@ -1218,6 +1218,16 @@ class TestPyffish(unittest.TestCase):
                 fen = sf.start_fen(variant)
                 self.assertEqual(sf.validate_fen(fen, variant), sf.FEN_OK)
 
+    def test_validate_fen_rejects_excessive_empty_counts(self):
+        invalid_fens = [
+            ("chess", "rnbqkbnr/pppppppp/8/10p3/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"),
+            ("capablanca", "rnabqkbcnr/pppppppppp/10/12p8/10/10/PPPPPPPPPP/RNABQKBCNR w KQkq - 0 1"),
+        ]
+
+        for variant, fen in invalid_fens:
+            with self.subTest(variant=variant, fen=fen):
+                self.assertEqual(sf.validate_fen(fen, variant), sf.FEN_INVALID_BOARD_GEOMETRY)
+
     def test_validate_fen_promoted_pieces(self):
         # Test promoted piece validation specifically
         


### PR DESCRIPTION
## Summary
- add bounds validation to `CharBoard::set_piece` and surface failures to callers
- reject overflowing file counters in `fill_char_board` before attempting to write
- exercise malformed FEN rows with excessive empty counts in the Python tests

## Testing
- python3 test.py *(fails: ModuleNotFoundError: No module named 'pyffish')*
- python3 -m pip install . *(fails: blocked from downloading build dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce1a571db48330a1210bf7db6d89d2