### PR TITLE
Fix Janggi rank notation and add regression test

### DIFF
--- a/src/apiutil.h
+++ b/src/apiutil.h
@@ -170,7 +170,16 @@ inline std::string rank(const Position& pos, Square s, Notation n) {
     case NOTATION_SHOGI_HODGES:
         return std::string(1, char('a' + pos.max_rank() - rank_of(s)));
     case NOTATION_JANGGI:
-        return std::to_string((pos.max_rank() - rank_of(s) + 1) % 10);
+    {
+        int boardHeight = pos.ranks();
+        int rawRank = pos.max_rank() - rank_of(s) + 1;
+        int displayRank = rawRank % boardHeight;
+
+        if (displayRank == 0)
+            displayRank = boardHeight;
+
+        return std::to_string(displayRank);
+    }
     case NOTATION_XIANGQI_WXF:
     {
         if (pos.empty(s))

--- a/test.py
+++ b/test.py
@@ -862,7 +862,8 @@ class TestPyffish(unittest.TestCase):
         self.assertEqual(result, "Hd5")
 
         result = sf.get_san("janggi", JANGGI, "b1c3", False, sf.NOTATION_JANGGI)
-        self.assertEqual(result, "H02-83")
+        self.assertEqual(result, "H102-83")
+        self.assertIn("10", result)
 
         fen = "1b1aa2b1/5k3/3ncn3/1pp1pp3/5r2p/9/P1PPB1PPB/2N1CCN1c/9/R2AKAR2 w - - 19 17"
         result = sf.get_san("janggi", fen, "d1e2", False, sf.NOTATION_SAN)


### PR DESCRIPTION
## Summary
- adjust the Janggi rank formatter to keep the raw rank value and map the back rank to 10 instead of 0
- update the Janggi SAN test to expect the corrected coordinate and assert the notation includes "10"

## Testing
- python3 test.py *(fails: ModuleNotFoundError: No module named 'pyffish')*

------
https://chatgpt.com/codex/tasks/task_e_68ce1a5b7c048330a1675c054445f7ac