### PR TITLE
Ensure variationSan restores state stack and add regression test

### DIFF
--- a/tests/js/ffish.d.ts
+++ b/tests/js/ffish.d.ts
@@ -55,6 +55,7 @@ export interface Board {
     fullmoveNumber(): number;
     halfmoveClock(): number;
     gamePly(): number;
+    stateStackSize(): number;
     hasInsufficientMaterial(turn: boolean): boolean;
     isInsufficientMaterial(): boolean;
     isGameOver(claimDraw?: boolean): boolean;

--- a/tests/js/test.js
+++ b/tests/js/test.js
@@ -282,6 +282,27 @@ describe('board.variationSan(uciMoves, notation, moveNumbers)', function () {
   });
 });
 
+describe('board.stateStackSize()', function () {
+  it("it remains aligned with the number of real moves after repeated variationSan calls", () => {
+    let board = new ffish.Board();
+    const actualMoves = ["e2e4", "e7e5", "g1f3"];
+    actualMoves.forEach(move => {
+      chai.expect(board.push(move)).to.equal(true);
+    });
+
+    const expectedStates = actualMoves.length + 1;
+    chai.expect(board.stateStackSize()).to.equal(expectedStates);
+
+    const variationLine = "g8f6 d2d3 Bf8c5";
+    for (let i = 0; i < 5; ++i) {
+      chai.expect(board.variationSan(variationLine)).to.not.equal("");
+      chai.expect(board.stateStackSize()).to.equal(expectedStates);
+    }
+
+    board.delete();
+  });
+});
+
 describe('board.turn()', function () {
   it("it returns the side to move", () => {
     let board = new ffish.Board();


### PR DESCRIPTION
## Summary
- track how many StateInfo entries variationSan pushes and pop them after undoing
- expose Board.stateStackSize() for callers and update the TypeScript definition
- add a JS regression test to ensure repeated variationSan calls leave the state stack unchanged

## Testing
- npm test *(fails: Cannot find module './ffish.js')*


------
https://chatgpt.com/codex/tasks/task_e_68ce42d4b7d88330a7825f2f36a42855