### PR TITLE
Gate PGN logging and add test coverage

### DIFF
--- a/src/ffishjs.cpp
+++ b/src/ffishjs.cpp
@@ -21,7 +21,8 @@
 #include <vector>
 #include <string>
 #include <sstream>
-#include<iostream>
+#include <iostream>
+#include <atomic>
 
 #include "misc.h"
 #include "types.h"
@@ -41,6 +42,10 @@
 using namespace emscripten;
 
 using namespace Stockfish;
+
+namespace {
+std::atomic<bool> logReadGamePgnMoves{false};
+}
 
 void initialize_stockfish() {
   pieceMap.init();
@@ -560,6 +565,10 @@ bool skip_comment(const std::string& pgn, size_t& curIdx, size_t& lineEnd) {
   return true;
 }
 
+void set_read_game_pgn_logging_enabled(bool enabled) {
+  logReadGamePgnMoves.store(enabled);
+}
+
 Game read_game_pgn(std::string pgn) {
   Game game;
   size_t lineStart = 0;
@@ -668,7 +677,8 @@ Game read_game_pgn(std::string pgn) {
           size_t annotationChar2 = sanMove.find('!');
           if (annotationChar1 != std::string::npos || annotationChar2 != std::string::npos)
             sanMove = sanMove.substr(0, std::min(annotationChar1, annotationChar2));
-          std::cout << sanMove << " ";
+          if (logReadGamePgnMoves.load())
+            std::cerr << sanMove << " ";
           game.board->push_san(sanMove);
         }
         curIdx = sanMoveEnd+1;
@@ -755,6 +765,7 @@ EMSCRIPTEN_BINDINGS(ffish_js) {
     .value("N_MOVE_RULE", N_MOVE_RULE)
     .value("N_FOLD_REPETITION", N_FOLD_REPETITION)
     .value("VARIANT_END", VARIANT_END);
+  function("setReadGamePGNLoggingEnabled", &set_read_game_pgn_logging_enabled);
   function("info", &ffish::info);
   function("setOption", &ffish::set_option<std::string>);
   function("setOptionInt", &ffish::set_option<int>);

--- a/tests/js/test.js
+++ b/tests/js/test.js
@@ -884,6 +884,34 @@ describe('ffish.readGamePGN(pgn)', function () {
      });
          }
   });
+  it("it does not write SAN moves to stdout when logging is disabled", () => {
+    const fs = require('fs');
+    const data = fs.readFileSync(pgnDir + 'c60_ruy_lopez.pgn', 'utf8');
+    ffish.setReadGamePGNLoggingEnabled(false);
+    const originalWrite = process.stdout.write;
+    let captured = '';
+    process.stdout.write = function(chunk, encoding, callback) {
+      if (typeof chunk === 'string') {
+        captured += chunk;
+      } else {
+        captured += chunk.toString(typeof encoding === 'string' ? encoding : undefined);
+      }
+      if (typeof callback === 'function') {
+        callback();
+      }
+      return true;
+    };
+    let game;
+    try {
+      game = ffish.readGamePGN(data);
+    } finally {
+      process.stdout.write = originalWrite;
+    }
+    chai.expect(captured).to.equal('');
+    if (game) {
+      game.delete();
+    }
+  });
 });
 
 describe('game.headerKeys()', function () {


### PR DESCRIPTION
## Summary
- gate `read_game_pgn` SAN logging behind an opt-in flag and send diagnostic output to `std::cerr`
- export a setter so callers can enable the diagnostic logging when needed
- add a mocha test that asserts `readGamePGN` does not write to stdout for a sample PGN

## Testing
- npm test *(fails: Cannot find module './ffish.js')*

------
https://chatgpt.com/codex/tasks/task_e_68ce42df0a3083308d1375a54db23579