### PR TITLE
Handle empty board pop

### DIFF
--- a/src/ffishjs.cpp
+++ b/src/ffishjs.cpp
@@ -157,10 +157,14 @@ public:
     return true;
   }
 
-  void pop() {
-    pos.undo_move(this->moveStack.back());
-    moveStack.pop_back();
-    states->pop_back();
+  bool pop() {
+    if (this->moveStack.empty())
+      return false;
+
+    this->pos.undo_move(this->moveStack.back());
+    this->moveStack.pop_back();
+    this->states->pop_back();
+    return true;
   }
 
   void reset() {

--- a/tests/js/ffish.d.ts
+++ b/tests/js/ffish.d.ts
@@ -44,7 +44,7 @@ export interface Board {
     numberLegalMoves(): number;
     push(uciMove: string): boolean;
     pushSan(sanMove: string, notation?: Notation): boolean;
-    pop(): void;
+    pop(): boolean;
     reset(): void;
     is960(): boolean;
     fen(showPromoted?: boolean, countStarted?: number): string;

--- a/tests/js/test.js
+++ b/tests/js/test.js
@@ -158,14 +158,21 @@ describe('board.pop()', function () {
     let board = new ffish.Board();
     board.push("e2e4");
     board.push("e7e5");
-    board.pop();
+    chai.expect(board.pop()).to.equal(true);
     board.push("e7e5");
     board.push("g1f3");
     board.push("b8c6");
     board.push("f1b5");
-    board.pop();
-    board.pop();
+    chai.expect(board.pop()).to.equal(true);
+    chai.expect(board.pop()).to.equal(true);
     chai.expect(board.fen()).to.equal("rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2");
+    board.delete();
+  });
+
+  it("it returns false when no move can be undone", () => {
+    let board = new ffish.Board();
+    chai.expect(board.pop()).to.equal(false);
+    chai.expect(board.fen()).to.equal("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
     board.delete();
   });
 });


### PR DESCRIPTION
## Summary
- return a boolean status from `Board::pop` and guard against empty move stacks before undoing
- update the TypeScript declaration so `pop` advertises the new return type
- extend the JavaScript tests to verify successful undos and the empty-stack behaviour

## Testing
- npm test *(fails: Cannot find module './ffish.js')*

------
https://chatgpt.com/codex/tasks/task_e_68ce42eb19e083308297b78a7e3e77b6